### PR TITLE
[new feature] access libraries using initMapApiLoader

### DIFF
--- a/src/lib/services/lazy-map-api-loader.js
+++ b/src/lib/services/lazy-map-api-loader.js
@@ -5,7 +5,8 @@ const DEFAULT_MAP_CONFIG = {
   hostAndPath: 'maps.googleapis.com/maps/api/js',
   callback: 'mapInitComponent',
   language: null,
-  region: null
+  region: null,
+  libraries: null
 }
 
 export default class MapAPILoader {
@@ -47,7 +48,7 @@ export default class MapAPILoader {
   _getScriptSrc() {
 
     const config = this._config
-    const paramKeys = ['key', 'callback', 'language', 'region']
+    const paramKeys = ['key', 'callback', 'language', 'region', 'libraries']
 
     const params = Object.keys(config)
       .filter(k => ~paramKeys.indexOf(k))


### PR DESCRIPTION
使用 initMapApiLoader 時，可以開放引入其他 google map api ，像是 street 或是 places。

開放接口如下:
```js
    VueMap.initMapApiLoader({
      key: YOUR_KEY,
      libraries: ['places', street'']
    })
```